### PR TITLE
Add name to package.json for nextjs-stack example

### DIFF
--- a/nextjs-stack/package.json
+++ b/nextjs-stack/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "nextjs-stack",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
This allows installing packages from the root using `bun install` for instance.